### PR TITLE
Undefined function fix

### DIFF
--- a/controller.php
+++ b/controller.php
@@ -33,5 +33,7 @@ function debugger()
 /**
  * Hooks
  */
-add_action('init', __NAMESPACE__ . '\loader');
-add_action('init', __NAMESPACE__ . '\debugger');
+if (function_exists('add_action')) {
+    add_action('init', __NAMESPACE__ . '\loader');
+    add_action('init', __NAMESPACE__ . '\debugger');
+}


### PR DESCRIPTION
When running `composer test` on Sage, it fails with a fatal error `Call to undefined function Sober\Controller\add_action()` as it is being loaded outside of Wordpress.