### PR TITLE
Update Debugger.php

### DIFF
--- a/src/Module/Debugger.php
+++ b/src/Module/Debugger.php
@@ -84,7 +84,7 @@ class Debugger
         $templates = array_reverse($templates);
         $path = get_stylesheet_directory() . '/controllers';
         $path = (has_filter('sober/controller/path') ? apply_filters('sober/controller/path', rtrim($path)) : get_stylesheet_directory() . '/controllers');
-        $path = str_replace(get_stylesheet_directory(), '', $path);
+        $path = str_replace($path, substr($path, strripos($path, '/')), $path);
         echo '<pre><strong>Hierarchy Debugger:</strong><ul>';
         foreach ($templates as $template) {
             if (strpos($template, '.blade.php') || $template === 'index.php') {


### PR DESCRIPTION
By default the folder of `controllers/` is in `resources/`, but I think that it's more suitable place in the folder `app/controller/`.

Therefore, I use the existing `sober/controller/path` filter with the value `get_theme_file_path () . '/app/controller'`, and everything seems to work, but it does not suit the fact that the output in the **Hierarchy Debugger** turns into something like `/Users/DieGOs/Sites/site.dev/web/app/themes/sage/app/controller/file .php`.

A modified line of code solves this problem. **Hierarchy Debugger** turns into `/controller-folder/file.php`.