### PR TITLE
Handle Empty ACF Items Array

### DIFF
--- a/src/Module/Acf.php
+++ b/src/Module/Acf.php
@@ -65,9 +65,14 @@ class Acf
         // Get $acf items
         $items = Acf::get($acf);
 
+        // Initialize data array
+        $data = [];
+
         // Create an array for each item returned
-        foreach ($items as $key => $item) {
-            $data[$key] = $item;
+        if (!empty($items)) {
+            foreach ($items as $key => $item) {
+                $data[$key] = $item;
+            }
         }
 
         // Return


### PR DESCRIPTION
Proposed solution for #65:

- don't throw an error in `foreach` if no items are returned from ACF
- return an empty array if no items are returned

If desired, array initialization can be avoided using PHP7's null coalesce operator: `return $data ?? [];`

As a side note, it's also noteworthy to add into the README that fields from the **options** page will not be returned.