### PR TITLE
use strpos and file_get_contents instead of exec and grep

### DIFF
--- a/src/Utils.php
+++ b/src/Utils.php
@@ -23,7 +23,7 @@ class Utils
      */
     public static function doesFileContain($filename, $str)
     {
-        return ((exec('grep ' . escapeshellarg($str) . ' ' . $filename)) ? true : false);
+        return  strpos(file_get_contents($filename), $str) !== false;
     }
 
     /**


### PR DESCRIPTION
My host was giving me 500 errors because they have disabled both exec and escapeshellarg for security reasons. I was able to accomplish the same effect with file_get_contents and strpos. I would imagine there are others whose hosts disable these functions for security measures as well.