### PR TITLE
Use ReflectionCLass getFileName of App\Controllers\App::class to dete…

### DIFF
--- a/src/Loader.php
+++ b/src/Loader.php
@@ -71,7 +71,8 @@ class Loader
      */
     protected function setPath()
     {
-        $this->path = get_theme_file_path() . '/' . strtolower(str_replace('\\', '/', $this->namespace));
+        $reflection = new \ReflectionClass($this->namespace .'\App');
+        $this->path = dirname($reflection->getFileName());
     }
 
     /**


### PR DESCRIPTION
Instead of using strtolower() of the namespace, utilize ReflectionClass::getFileName to get the full path of the App class in whatever namespace has been defined.