### PR TITLE
Allow ACF Pro options to be passed to blade templates

### DIFF
--- a/src/Controller.php
+++ b/src/Controller.php
@@ -12,6 +12,7 @@ class Controller
     protected $template = false;
     protected $tree = false;
     protected $acf = false;
+    protected $acfPro = false;
 
     // Controller
     private $class;
@@ -223,6 +224,9 @@ class Controller
         if ($this->acf) {
             // Fetch current page Acf data and merge with $this->data
             $this->data = array_merge($this->data, Acf::getModuleData($this->acf));
+        }
+        if($this->acfPro){
+            $this->data = array_merge($this->data, Acf::getModuleData('options'));
         }
     }
 

--- a/src/Module/Acf.php
+++ b/src/Module/Acf.php
@@ -29,7 +29,10 @@ class Acf
         }
 
         // Get field from string
-        if (is_string($items)) {
+        if($items === 'options'){
+            $data = Acf::convert(get_fields('options'));
+        }
+        elseif (is_string($items)) {
             $data = Acf::convert(get_field($items));
         }
 
@@ -58,16 +61,24 @@ class Acf
         }
 
         // If $acf is string convert to array to get key included
-        if (is_string($acf)) {
+        if (is_string($acf) && $acf !== 'options') {
             $acf = [$acf];
         }
 
         // Get $acf items
         $items = Acf::get($acf);
 
+        if(!$items){
+            $items = [];
+        }
+
+
         // Create an array for each item returned
         foreach ($items as $key => $item) {
             $data[$key] = $item;
+        }
+        if(!$data){
+            $data = [];
         }
 
         // Return


### PR DESCRIPTION
To enable ACF pro options, simply set `protected $acfPro = true;` on a Controller class. If set on the App class, Tree can be implemented on the other controllers to inherit the fields.

This resolves #67 and should also resolve #65 