### PR TITLE
Integrate ACF Options whenever property acf is set

### DIFF
--- a/src/Controller.php
+++ b/src/Controller.php
@@ -12,7 +12,6 @@ class Controller
     protected $template = false;
     protected $tree = false;
     protected $acf = false;
-    protected $acfPro = false;
 
     // Controller
     private $class;
@@ -224,8 +223,6 @@ class Controller
         if ($this->acf) {
             // Fetch current page Acf data and merge with $this->data
             $this->data = array_merge($this->data, Acf::getModuleData($this->acf));
-        }
-        if($this->acfPro){
             $this->data = array_merge($this->data, Acf::getModuleData('options'));
         }
     }

--- a/src/Controller.php
+++ b/src/Controller.php
@@ -223,9 +223,6 @@ class Controller
         if ($this->acf) {
             // Fetch current page Acf data and merge with $this->data
             $this->data = array_merge($this->data, Acf::getModuleData($this->acf));
-            if(function_exists('acf_add_options_page')){
-                $this->data = array_merge($this->data, Acf::getModuleData('options'));
-            }
         }
     }
 

--- a/src/Controller.php
+++ b/src/Controller.php
@@ -12,6 +12,7 @@ class Controller
     protected $template = false;
     protected $tree = false;
     protected $acf = false;
+    protected $acfPro = false;
 
     // Controller
     private $class;
@@ -223,6 +224,9 @@ class Controller
         if ($this->acf) {
             // Fetch current page Acf data and merge with $this->data
             $this->data = array_merge($this->data, Acf::getModuleData($this->acf));
+        }
+        if($this->acfPro){
+            $this->data = array_merge($this->data, Acf::getModuleData('options'));
         }
     }
 

--- a/src/Controller.php
+++ b/src/Controller.php
@@ -223,7 +223,9 @@ class Controller
         if ($this->acf) {
             // Fetch current page Acf data and merge with $this->data
             $this->data = array_merge($this->data, Acf::getModuleData($this->acf));
-            $this->data = array_merge($this->data, Acf::getModuleData('options'));
+            if(function_exists('acf_add_options_page')){
+                $this->data = array_merge($this->data, Acf::getModuleData('options'));
+            }
         }
     }
 

--- a/src/Module/Acf.php
+++ b/src/Module/Acf.php
@@ -28,11 +28,7 @@ class Acf
             $data = Acf::convert(get_fields());
         }
 
-        // Get field from string
-        if($items === 'options'){
-            $data = Acf::convert(get_fields('options'));
-        }
-        elseif (is_string($items)) {
+        if (is_string($items)) {
             $data = Acf::convert(get_field($items));
         }
 
@@ -41,6 +37,11 @@ class Acf
             foreach ($items as $item) {
                 $data[$item] = Acf::convert(get_field($item));
             }
+        }
+
+        if(function_exists('acf_add_options_page')){
+            $options = Acf::convert(get_fields('options'));
+            $data = (object) array_merge((array)$data, (array) $options);
         }
 
         // Return

--- a/src/Module/Acf.php
+++ b/src/Module/Acf.php
@@ -28,6 +28,7 @@ class Acf
             $data = Acf::convert(get_fields());
         }
 
+        // Get field from string
         if (is_string($items)) {
             $data = Acf::convert(get_field($items));
         }
@@ -62,7 +63,7 @@ class Acf
         }
 
         // If $acf is string convert to array to get key included
-        if (is_string($acf) && $acf !== 'options') {
+        if (is_string($acf)) {
             $acf = [$acf];
         }
 

--- a/src/Module/Acf.php
+++ b/src/Module/Acf.php
@@ -29,7 +29,10 @@ class Acf
         }
 
         // Get field from string
-        if (is_string($items)) {
+        if($items === 'options'){
+            $data = Acf::convert(get_fields('options'));
+        }
+        elseif (is_string($items)) {
             $data = Acf::convert(get_field($items));
         }
 
@@ -58,16 +61,24 @@ class Acf
         }
 
         // If $acf is string convert to array to get key included
-        if (is_string($acf)) {
+        if (is_string($acf) && $acf !== 'options') {
             $acf = [$acf];
         }
 
         // Get $acf items
         $items = Acf::get($acf);
 
+        if(!$items){
+            $items = [];
+        }
+
+
         // Create an array for each item returned
         foreach ($items as $key => $item) {
             $data[$key] = $item;
+        }
+        if(!$data){
+            $data = [];
         }
 
         // Return


### PR DESCRIPTION
When $acf is set to any value on the App class, it checks for acf_add_options_page and then merges that data with the existing acf data. Options are then passed to the blade view in the same manner.