### PR TITLE
Fix subtle filepath error in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ class Archive extends Controller
 
 You can also create reusable components and include them in any Controller class using PHP traits.
 
-**app/Controllers/partials/Images.php**
+**app/Controllers/Partials/Images.php**
 
 ```php
 <?php


### PR DESCRIPTION
Capitalize 'Partials' to resolve an error on filesystems that are case-sensitive.

I encountered this issue when upgrading from 9.0.0-beta.4. While working in a dev environment, traits were loaded fine. Once moving to a staging server however, it wasn't loading the file and triggering a fatal error.