### PR TITLE
Pass queried object ID to ACF get_field(s) functions

### DIFF
--- a/src/Module/Acf.php
+++ b/src/Module/Acf.php
@@ -73,19 +73,19 @@ class Acf
      */
     public function setData($acf)
     {
-        $query = get_queried_object();
+        $objectId = get_queried_object_id();
 
         if (is_bool($acf)) {
-            $this->data = get_fields($query);
+            $this->data = get_fields($objectId);
         }
 
         if (is_string($acf)) {
-            $this->data = [$acf => get_field($acf, $query)];
+            $this->data = [$acf => get_field($acf, $object_Id)];
         }
 
         if (is_array($acf)) {
             foreach ($acf as $item) {
-                $this->data[$item] = get_field($item, $query);
+                $this->data[$item] = get_field($item, $objectId);
             }
         }
     }


### PR DESCRIPTION
Related to #101 

Actuallty ACF is not happy and throws warnings if you pass the full object instead of the expected ID.

See the `get_fields()` parameters: https://www.advancedcustomfields.com/resources/get_fields/
`post_id`parameter is expected to be integer or string (not `WP_Post`).