### PR TITLE
Add missing $reflection definition in Loader

### DIFF
--- a/src/Loader.php
+++ b/src/Loader.php
@@ -100,6 +100,7 @@ class Loader
             }
 
             // Exclude non-Controller classes
+            $reflection = new \ReflectionClass($this->namespace .'\App');
             if (!$reflection->isSubclassOf('Sober\Controller\Controller')) {
                 continue;
             }


### PR DESCRIPTION
@darrenjacoby 

From https://github.com/soberwp/controller/commit/729119c7b6b1eeb2db86500c7a03de16a70e8de0

discovered by @phpstan